### PR TITLE
Testcases reflect the command line arg changes (engines without y/n)

### DIFF
--- a/tests/fastercap/fastercap_test.py
+++ b/tests/fastercap/fastercap_test.py
@@ -92,7 +92,7 @@ def _extract_single_cell(*path_components) -> Tuple[CSVPath, PNGPath]:
               '--pdk', 'sky130A',
               '--gds', gds_path,
               '--out_dir', output_dir_path,
-              '--fastercap', 'y'])
+              '--fastercap'])
     assert cli.fastercap_extracted_csv_path is not None
     return cli.fastercap_extracted_csv_path, preview_png_path
 

--- a/tests/rcx25/rcx25_test.py
+++ b/tests/rcx25/rcx25_test.py
@@ -93,7 +93,7 @@ def _run_rcx25d_single_cell(*path_components) -> Tuple[CellExtractionResults, CS
               '--pdk', 'sky130A',
               '--gds', gds_path,
               '--out_dir', output_dir_path,
-              '--2.5D', 'y'])
+              '--2.5D'])
     assert cli.rcx25_extraction_results is not None
     assert len(cli.rcx25_extraction_results.cell_extraction_results) == 1  # assume single cell test
     results = list(cli.rcx25_extraction_results.cell_extraction_results.values())[0]


### PR DESCRIPTION
Follow up to #41 