### PR TITLE
Revert "Reimplementation of pmap in Python (needed by LVS), for win/macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ python = "^3.12"
 cairosvg = "^2.7.1"
 klayout = "^0.29.10"    # required minimum version because of EdgeNeighborhoodVisitor
 matplotlib = "^3.10.1"
-openpdk-pmap = { version = "^0.0.1", markers = "sys_platform == 'win32' or sys_platform == 'darwin'" }
 protobuf = "^5.29.1"
 rich = "^13.9.4"
+protobuf = "^5.29.1"
 rich-argparse = "^1.6.0"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
This reverts commit e343c8ce028727ca6b9fdaa84eebd9811fe1e75f.