### PR TITLE
KPEX/2.5D: SPICE netlist generation

### DIFF
--- a/klayout_pex/kpex_cli.py
+++ b/klayout_pex/kpex_cli.py
@@ -43,6 +43,7 @@ from typing import *
 import klayout.db as kdb
 import klayout.rdb as rdb
 
+from klayout_pex.rcx25.netlist_expander import RCX25NetlistExpander
 from .fastercap.fastercap_input_builder import FasterCapInputBuilder
 from .fastercap.fastercap_model_generator import FasterCapModelGenerator
 from .fastercap.fastercap_runner import run_fastercap, fastercap_parse_capacitance_matrix
@@ -675,7 +676,8 @@ class KpexCLI:
                              pex_context: KLayoutExtractionContext,
                              tech_info: TechInfo,
                              report_path: str,
-                             netlist_csv_path: str):
+                             netlist_csv_path: Optional[str],
+                             expanded_netlist_path: Optional[str]):
         # TODO: make this separatly configurable
         #       for now we use 0
         args.rcx25d_delaunay_amax = 0
@@ -690,24 +692,43 @@ class KpexCLI:
                                    report_path=report_path)
         extraction_results = extractor.extract()
 
-        with open(netlist_csv_path, 'w', encoding='utf-8') as f:
-            summary = extraction_results.summarize()
+        if netlist_csv_path is not None:
+            # TODO: merge this with klayout_pex/klayout/netlist_csv.py
 
-            f.write('Device;Net1;Net2;Capacitance [fF];Resistance [Ω]\n')
-            for idx, (key, cap_value) in enumerate(summary.capacitances.items()):
-                # f.write(f"C{idx + 1};{key.net1};{key.net2};{cap_value / 1e15};{round(cap_value, 3)}\n")
-                f.write(f"C{idx + 1};{key.net1};{key.net2};{round(cap_value, 3)};\n")
-            for idx, (key, res_value) in enumerate(summary.resistances.items()):
-                f.write(f"R{idx + 1};{key.net1};{key.net2};;{round(res_value, 3)}\n")
+            with open(netlist_csv_path, 'w', encoding='utf-8') as f:
+                summary = extraction_results.summarize()
 
-        rule("kpex/2.5D extracted netlist (CSV format):")
-        with open(netlist_csv_path, 'r') as f:
-            for line in f.readlines():
-                subproc(line[:-1])  # abusing subproc, simply want verbatim
+                f.write('Device;Net1;Net2;Capacitance [fF];Resistance [Ω]\n')
+                for idx, (key, cap_value) in enumerate(sorted(summary.capacitances.items())):
+                    # f.write(f"C{idx + 1};{key.net1};{key.net2};{cap_value / 1e15};{round(cap_value, 3)}\n")
+                    f.write(f"C{idx + 1};{key.net1};{key.net2};{round(cap_value, 3)};\n")
+                for idx, (key, res_value) in enumerate(sorted(summary.resistances.items())):
+                    f.write(f"R{idx + 1};{key.net1};{key.net2};;{round(res_value, 3)}\n")
 
-        rule("Extracted netlist CSV")
-        subproc(f"{netlist_csv_path}")
+            rule('kpex/2.5D extracted netlist (CSV format)')
+            with open(netlist_csv_path, 'r') as f:
+                for line in f.readlines():
+                    subproc(line[:-1])  # abusing subproc, simply want verbatim
 
+            rule('Extracted netlist CSV')
+            subproc(f"{netlist_csv_path}")
+
+        if expanded_netlist_path is not None:
+            rule('kpex/2.5D extracted netlist (SPICE format)')
+            netlist_expander = RCX25NetlistExpander()
+            expanded_netlist = netlist_expander.expand(
+                extracted_netlist=pex_context.lvsdb.netlist(),
+                top_cell_name=pex_context.annotated_top_cell.name,
+                extraction_results=extraction_results,
+                blackbox_devices=args.blackbox_devices
+            )
+
+            spice_writer = kdb.NetlistSpiceWriter()
+            spice_writer.use_net_names = True
+            spice_writer.with_comments = False
+            expanded_netlist.write(expanded_netlist_path, spice_writer)
+            rule()
+            info(f"Wrote expanded netlist to: {expanded_netlist_path}")
 
         # NOTE: there was a KLayout bug that some of the categories were lost,
         #       so that the marker browser could not load the report file
@@ -910,14 +931,18 @@ class KpexCLI:
         if args.run_2_5D:
             rule("kpex/2.5D PEX Engine")
             report_path = os.path.join(args.output_dir_path, f"{args.effective_cell_name}_k25d_pex_report.rdb.gz")
-            netlist_csv_path = os.path.abspath(os.path.join(args.output_dir_path, f"{args.effective_cell_name}_k25d_pex_netlist.csv"))
+            netlist_csv_path = os.path.abspath(os.path.join(args.output_dir_path,
+                                                            f"{args.effective_cell_name}_k25d_pex_netlist.csv"))
+            netlist_spice_path = os.path.abspath(os.path.join(args.output_dir_path,
+                                                              f"{args.effective_cell_name}_k25d_pex_netlist.spice"))
 
             self._rcx25_extraction_results = self.run_kpex_2_5d_engine(  # NOTE: store for test case
                 args=args,
                 pex_context=pex_context,
                 tech_info=tech_info,
                 report_path=report_path,
-                netlist_csv_path=netlist_csv_path
+                netlist_csv_path=netlist_csv_path,
+                expanded_netlist_path=netlist_spice_path
             )
 
             self._rcx25_extracted_csv_path = netlist_csv_path

--- a/klayout_pex/kpex_cli.py
+++ b/klayout_pex/kpex_cli.py
@@ -76,7 +76,7 @@ from .magic.magic_runner import (
 )
 from .magic.magic_log_analyzer import MagicLogAnalyzer
 from .pdk_config import PDKConfig
-from .rcx25.extractor import RCExtractor, ExtractionResults
+from .rcx25.extractor import RCX25Extractor, ExtractionResults
 from .rcx25.pex_mode import PEXMode
 from .tech_info import TechInfo
 from .util.multiple_choice import MultipleChoicePattern
@@ -681,13 +681,13 @@ class KpexCLI:
         args.rcx25d_delaunay_amax = 0
         args.rcx25d_delaunay_b = 0.5
 
-        extractor = RCExtractor(pex_context=pex_context,
-                                pex_mode=args.pex_mode,
-                                delaunay_amax=args.rcx25d_delaunay_amax,
-                                delaunay_b=args.rcx25d_delaunay_b,
-                                scale_ratio_to_fit_halo=args.scale_ratio_to_fit_halo,
-                                tech_info=tech_info,
-                                report_path=report_path)
+        extractor = RCX25Extractor(pex_context=pex_context,
+                                   pex_mode=args.pex_mode,
+                                   delaunay_amax=args.rcx25d_delaunay_amax,
+                                   delaunay_b=args.rcx25d_delaunay_b,
+                                   scale_ratio_to_fit_halo=args.scale_ratio_to_fit_halo,
+                                   tech_info=tech_info,
+                                   report_path=report_path)
         extraction_results = extractor.extract()
 
         with open(netlist_csv_path, 'w', encoding='utf-8') as f:

--- a/klayout_pex/rcx25/extraction_results.py
+++ b/klayout_pex/rcx25/extraction_results.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import *
 
-from .r.resistor_network import MultiLayerResistanceNetwork, ViaJunction, DeviceTerminal
+from .r.resistor_network import MultiLayerResistanceNetwork, ViaJunction, DeviceTerminal, Conductance
 from .types import NetName, LayerName, CellName
 import klayout_pex_protobuf.process_parasitics_pb2 as process_parasitics_pb2
 from ..log import error

--- a/klayout_pex/rcx25/extraction_results.py
+++ b/klayout_pex/rcx25/extraction_results.py
@@ -105,7 +105,7 @@ class SideOverlapCap:
         return f"(Side Overlap): {self.key} = {round(self.cap_value, 6)}fF"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class NetCoupleKey:
     net1: NetName
     net2: NetName

--- a/klayout_pex/rcx25/extractor.py
+++ b/klayout_pex/rcx25/extractor.py
@@ -51,7 +51,7 @@ from .r.resistor_network import (
 )
 
 
-class RCExtractor:
+class RCX25Extractor:
     def __init__(self,
                  pex_context: KLayoutExtractionContext,
                  pex_mode: PEXMode,

--- a/klayout_pex/rcx25/netlist_expander.py
+++ b/klayout_pex/rcx25/netlist_expander.py
@@ -1,0 +1,116 @@
+#
+# --------------------------------------------------------------------------------
+# SPDX-FileCopyrightText: 2024 Martin Jan Köhler and Harald Pretl
+# Johannes Kepler University, Institute for Integrated Circuits.
+#
+# This file is part of KPEX 
+# (see https://github.com/martinjankoehler/klayout-pex).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# SPDX-License-Identifier: GPL-3.0-or-later
+# --------------------------------------------------------------------------------
+#
+from __future__ import annotations
+
+import re
+from typing import *
+
+import klayout.db as kdb
+
+from ..log import (
+    info,
+    warning,
+)
+from .extraction_results import ExtractionResults
+
+
+class RCX25NetlistExpander:
+    @staticmethod
+    def expand(extracted_netlist: kdb.Netlist,
+               top_cell_name: str,
+               extraction_results: ExtractionResults,
+               blackbox_devices: bool) -> kdb.Netlist:
+        expanded_netlist: kdb.Netlist = extracted_netlist.dup()
+        top_circuit: kdb.Circuit = expanded_netlist.circuit_by_name(top_cell_name)
+
+        if not blackbox_devices:
+            # TODO: we'll need additional information about the available devices
+            #       because we only want to replace resistor / capacitor devices
+            #       and for example not transitors
+
+            for d in top_circuit.each_device():
+                name = d.name or d.expanded_name()
+                info(f"Removing whiteboxed device {name}")
+                top_circuit.remove_device(d)
+
+        # create capacitor device class
+        cap = kdb.DeviceClassCapacitor()
+        # cap.name = 'KPEX_CAP'
+        cap.description = "Extracted by KPEX/2.5D"
+        expanded_netlist.add(cap)
+
+        # create resistor device class
+        res = kdb.DeviceClassResistor()
+        # res.name = 'KPEX_RES'
+        res.description = "Extracted by KPEX/2.5D"
+        expanded_netlist.add(res)
+
+        fc_gnd_net = top_circuit.create_net('FC_GND')  # create GROUND net
+        vsubs_net = top_circuit.create_net("VSUBS")
+
+        summary = extraction_results.summarize()
+        cap_items = sorted(summary.capacitances.items())
+        res_items = sorted(summary.resistances.items())
+
+        # build table: name -> net
+        name2net: Dict[str, kdb.Net] = {n.expanded_name(): n for n in top_circuit.each_net()}
+
+        def add_net_if_needed(net_name: str):
+            if net_name in name2net:
+                return
+            name2net[net_name] = top_circuit.create_net(net_name)
+
+        # add additional nets for new nodes (e.g. created during R extraction of vias)
+        for key, _ in cap_items:
+            add_net_if_needed(key.net1)
+            add_net_if_needed(key.net2)
+        for key, _ in res_items:
+            add_net_if_needed(key.net1)
+            add_net_if_needed(key.net2)
+
+        for idx, (key, cap_value) in enumerate(cap_items):
+            net1 = name2net[key.net1]
+            net2 = name2net[key.net2]
+
+            c: kdb.Device = top_circuit.create_device(cap, f"ext_{idx+1}")
+            c.connect_terminal('A', net1)
+            c.connect_terminal('B', net2)
+            c.set_parameter('C', cap_value)
+            if net1 == net2:
+                warning(f"Invalid attempt to create cap {c.name} between "
+                        f"same net {net1} with value {'%.12g' % cap_value}")
+
+        for idx, (key, res_value) in enumerate(res_items):
+            net1 = name2net[key.net1]
+            net2 = name2net[key.net2]
+
+            r: kdb.Device = top_circuit.create_device(res, f"ext_{idx+1}")
+            r.connect_terminal('A', net1)
+            r.connect_terminal('B', net2)
+            r.set_parameter('R', res_value)
+            if net1 == net2:
+                warning(f"Invalid attempt to create resistor {r.name} between "
+                        f"same net {net1} with value {'%.12g' % res_value}")
+
+        return expanded_netlist


### PR DESCRIPTION
Fixes  #76

- numbering of parasitic devices is now sorted by net names
   - BTW: should also fix failing testcases (due to comparing netlist CSVs with differet ordering caused by iterating unordered hash table)
- SPICE netlist generation is now also done for KPEX/2.5D