### PR TITLE
feat(magic): add 'dsubcircuit' as a device type

### DIFF
--- a/klayout_pex/magic/magic_ext_data_structures.py
+++ b/klayout_pex/magic/magic_ext_data_structures.py
@@ -70,6 +70,7 @@ class DeviceType(StrEnum):
     RSUBCKT = "rsubckt"
     MSUBCKT = "msubckt"
     CSUBCKT = "csubckt"
+    DSUBCKT = "dsubckt"
 
 
 @dataclass


### PR DESCRIPTION
This type is the same as a csubcircuit, only with the terminals flipped, i.e. (anode, cathode) rather than (cathode, anode)[1].

This subcircuit type is currently used in the IHP PDK, specifically for `dantenna`, for reference:

``` 
# Diodes
 device csubcircuit dpantenna *pdiode nwell w=w l=l
 device dsubcircuit dantenna *ndiode pwell,space/w w=w l=l
 device subcircuit schottky *schottky *hvnsd nwell error w=w l=l
```

Fixes: `ValueError: 'dsubckt' is not a valid DeviceType` when running on a GDS with `dsubcircuit`

\[1\]: http://opencircuitdesign.com/magic/techref/maint2.html