### PR TITLE
fix(fastcap): Replace os.chdir with subprocess cwd parameter

### DIFF
--- a/klayout_pex/fastcap/fastcap_runner.py
+++ b/klayout_pex/fastcap/fastcap_runner.py
@@ -53,8 +53,6 @@ def run_fastcap(exe_path: str,
     log_path = os.path.abspath(log_path)
     lst_file_path = os.path.basename(lst_file_path)
 
-    info(f"Chdir to {work_dir}")
-    os.chdir(work_dir)
     args = [
         exe_path,
         f"-o{expansion_order}",
@@ -71,13 +69,14 @@ def run_fastcap(exe_path: str,
         f"-l{lst_file_path}",
     ]
 
-    info(f"Calling FastCap2")
+    info(f"Calling FastCap2 in {work_dir}")
     subproc(f"{' '.join(args)}, output file: {log_path}")
 
     rule('FastCap Output')
     start = time.time()
 
     proc = subprocess.Popen(args,
+                            cwd=work_dir,
                             stdin=subprocess.DEVNULL,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,


### PR DESCRIPTION
## Problem

When trying to run extraction using `--fastcap`, I get the error:

```python
    cap_matrix = fastcap_parse_capacitance_matrix(log_path)
  File "/usr/lib/python3.14/site-packages/klayout_pex/fastcap/fastcap_runner.py", line 113, in fastcap_parse_capacitance_matrix
    with open(log_path, 'r') as f:
         ~~~~^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'output/dpatenna__TOP/TOP_FastCap2_Output.txt'
```

The root cause is that `run_fastcap()` calls `os.chdir()` and never restores the original directory. 
The post-processors rely on relative paths, and due to the `chdir`, these relative paths are now incorrect.

## Solution

Use the `cwd` parameter of `subprocess.Popen()` to set the working directory for just the FastCap subprocess, rather than changing the parent process's directory.