### PR TITLE
Infer PDK Arg from Environment Variable

### DIFF
--- a/klayout_pex/env.py
+++ b/klayout_pex/env.py
@@ -29,6 +29,9 @@ from enum import StrEnum
 import os
 from typing import *
 
+from .pdk_config import PDK
+from .log import warning
+
 
 class EnvVar(StrEnum):
     FASTCAP_EXE = 'KPEX_FASTCAP_EXE'
@@ -87,6 +90,17 @@ class Env:
             None if PDK_ROOT is None or PDK is None \
             else os.path.abspath(f"{PDK_ROOT}/{PDK}/libs.tech/magic/{PDK}.magicrc")
         return default_magicrc_path
+
+    @property
+    def default_pdk(self) -> Optional[PDK]:
+        pdk_str = self[EnvVar.PDK]
+        if pdk_str is None:
+            return None
+        try:
+            return PDK.from_string(pdk_str)
+        except ValueError:
+            warning(f"Ignoring invalid PDK specified in environment variable {EnvVar.PDK.value}: '{pdk_str}'")
+            return None
 
     def __getitem__(self, env_var: EnvVar) -> Optional[str]:
         return self._data[env_var]

--- a/klayout_pex/kpex_cli.py
+++ b/klayout_pex/kpex_cli.py
@@ -131,9 +131,14 @@ class KpexCLI:
 
         all_pdk_choices = list(PDK) + list(PDK.legacy_aliases().keys())
 
-        group_pex.add_argument("--pdk", dest="pdk", required=True,
+        default_pdk = env.default_pdk
+        pdk_help = render_enum_help(topic='pdk', enum_cls=PDK, print_default=False)
+        if default_pdk:
+            pdk_help += f" (default is '{default_pdk}')"
+
+        group_pex.add_argument("--pdk", dest="pdk", required=default_pdk is None,
                                type=PDK.from_string, choices=all_pdk_choices,
-                               help=render_enum_help(topic='pdk', enum_cls=PDK))
+                               help=pdk_help, default=default_pdk)
 
         group_pex.add_argument("--out_dir", dest="output_dir_base_path", default="output",
                                help="Run directory path (default is '%(default)s')")

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -30,6 +30,7 @@ from typing import *
 import unittest
 
 from klayout_pex.env import Env, EnvVar
+from klayout_pex.pdk_config import PDK
 
 
 @allure.parent_suite("Unit Tests")
@@ -63,3 +64,13 @@ class Test(unittest.TestCase):
             self.assertEqual(value_for_var(var), val,
                              f"Envrionmental variable {var.value} was set to '{value_for_var(var)}', "
                              f"but Env['{var.value}'] returns '{val}'!")
+
+    def test_valid_pdk_from_env(self):
+        os.environ[EnvVar.PDK.value] = 'sky130A'
+        env = Env.from_os_environ()
+        self.assertEqual(PDK.SKY130A, env.default_pdk)
+
+    def test_invalid_pdk_from_env(self):
+        os.environ[EnvVar.PDK.value] = 'invalid_pdk'
+        env = Env.from_os_environ()
+        self.assertIsNone(env.default_pdk)


### PR DESCRIPTION
Make `--pdk` optional when the `PDK` env var is set (the same var used for finding the default `.magicrc`). If `PDK` is unset or not a valid pdk, then `--pdk` is still required.

Addresses #162